### PR TITLE
Resolve issue #21

### DIFF
--- a/docs/resolve-issue-21.md
+++ b/docs/resolve-issue-21.md
@@ -1,0 +1,146 @@
+# Resolve Issue #21: Layout Viewport Options
+
+## Goal
+
+Add `minLayoutViewport` and `maxLayoutViewport` options so fluid values match exact design breakpoints (e.g. Figma artboards) while the fluid scaling continues beyond those points until clamped at the global viewport boundaries.
+
+## Problem
+
+Currently, `minViewport` and `maxViewport` serve dual purposes:
+1. The points where min/max values are reached
+2. The clamp boundaries (where scaling stops)
+
+Users working with Figma need values to match at specific layout widths (e.g. 480px mobile, 1024px desktop) but want fluid scaling to continue beyond those points for a smoother experience on very small or very large screens.
+
+## Proposed Syntax
+
+### Global config
+
+```css
+@plugin "fluid-tailwindcss" {
+  minViewport: 375;
+  maxViewport: 1440;
+  minLayoutViewport: 480;
+  maxLayoutViewport: 1024;
+}
+```
+
+### Behavior
+
+With `fl-p-4/8` (16px → 32px):
+
+| Viewport | Current behavior | New behavior (with layout viewports) |
+|----------|-----------------|--------------------------------------|
+| 375px | 16px (clamped) | ~12.7px (clamped) |
+| 480px | ~18.5px (scaling) | 16px (matches Figma mobile) |
+| 900px | ~25px (scaling) | ~28.4px (scaling) |
+| 1024px | ~27px (scaling) | 32px (matches Figma desktop) |
+| 1440px | 32px (clamped) | ~44.2px (clamped) |
+
+### Math
+
+```
+slope = (maxValue - minValue) / (maxLayoutViewport - minLayoutViewport)
+      = (32 - 16) / (1024 - 480)
+      = 0.0294 px/px
+
+extrapolatedMin = minValue - slope * (minLayoutViewport - minViewport)
+                = 16 - 0.0294 * (480 - 375)
+                = 12.91px
+
+extrapolatedMax = maxValue + slope * (maxViewport - maxLayoutViewport)
+                = 32 + 0.0294 * (1440 - 1024)
+                = 44.24px
+
+Result: clamp(12.91px, <slope based on 375→1440 range>, 44.24px)
+```
+
+The slope in the clamp formula uses the **viewport** range (375→1440) since that's the actual vw scaling range. The layout viewports only determine where the "design values" land on that line.
+
+## Examples
+
+### Example 1: Typography matching Figma
+
+```css
+@plugin "fluid-tailwindcss" {
+  minViewport: 375;
+  maxViewport: 1920;
+  minLayoutViewport: 768;
+  maxLayoutViewport: 1440;
+}
+```
+
+```html
+<h1 class="fl-text-2xl/5xl">Heading</h1>
+```
+
+- At 768px → exactly `1.5rem` (matches tablet Figma)
+- At 1440px → exactly `3rem` (matches desktop Figma)
+- Below 768px → keeps shrinking until clamped at 375px
+- Above 1440px → keeps growing until clamped at 1920px
+
+### Example 2: Spacing with breathing room
+
+```css
+@plugin "fluid-tailwindcss" {
+  minViewport: 320;
+  maxViewport: 1600;
+  minLayoutViewport: 375;
+  maxLayoutViewport: 1440;
+}
+```
+
+```html
+<section class="fl-px-4/16">
+  Content with fluid horizontal padding
+</section>
+```
+
+- At 375px → exactly `1rem` padding
+- At 1440px → exactly `4rem` padding
+- At 320px → slightly less than 1rem (extrapolated)
+- At 1600px → slightly more than 4rem (extrapolated)
+
+### Example 3: Without layout viewports (no change)
+
+If `minLayoutViewport` / `maxLayoutViewport` are not set, behavior is identical to current:
+
+```css
+@plugin "fluid-tailwindcss" {
+  minViewport: 375;
+  maxViewport: 1440;
+}
+```
+
+```html
+<div class="fl-p-4/8">Same as today</div>
+```
+
+## Tasks
+
+- [ ] Add `minLayoutViewport` and `maxLayoutViewport` to `FluidOptions` in `src/types.ts` (with lowercase aliases for Prettier).
+- [ ] Add the fields to `ResolvedFluidOptions` (optional, default to `undefined`).
+- [ ] Update option resolution in `src/index.ts` to pass layout viewports through.
+- [ ] Add an extrapolation function in `src/clamp.ts` that recalculates min/max values when layout viewports are present.
+- [ ] Ensure the extrapolation works with both `rem` and `px` output modes.
+- [ ] Ensure per-utility breakpoint ranges (`fl-p-4/8--md-lg`) still override correctly — layout viewports should NOT apply when a per-class range is specified.
+- [ ] Add tests: global layout viewport config produces correct extrapolated clamp values.
+- [ ] Add tests: layout viewports are ignored when per-utility breakpoint range is used.
+- [ ] Add tests: omitting layout viewports produces identical output to current behavior (no regression).
+- [ ] Add tests: edge case where `minLayoutViewport === minViewport` (no extrapolation on min side).
+- [ ] Run `pnpm test:run` and `pnpm lint` → verify all pass.
+
+## Constraints
+
+- Layout viewports must be between the global viewport boundaries: `minViewport <= minLayoutViewport < maxLayoutViewport <= maxViewport`.
+- If layout viewports equal the global viewports, behavior is identical to current (no-op).
+- Validation should warn if layout viewports are outside the global viewport range.
+- This is purely additive — no breaking changes to existing behavior.
+
+## Done When
+
+- [ ] `fl-p-4/8` with layout viewports produces extrapolated clamp values.
+- [ ] `fl-text-base/2xl` with layout viewports produces correct fluid typography.
+- [ ] Omitting layout viewports produces identical output to current version.
+- [ ] Per-utility breakpoint ranges bypass layout viewport extrapolation.
+- [ ] All existing tests still pass.

--- a/src/clamp.ts
+++ b/src/clamp.ts
@@ -596,6 +596,29 @@ export function calculateClampAdvanced(
   const minViewportRem = minViewport / rootFontSize;
   const maxViewportRem = maxViewport / rootFontSize;
 
+  // Layout viewport extrapolation: when layout viewports are set and no
+  // per-utility breakpoint override is active, the user-specified min/max values
+  // correspond to the layout viewport boundaries. We extrapolate the linear
+  // slope to find what values land at the global viewport boundaries.
+  const hasBreakpointOverride = overrides?.minViewport != null || overrides?.maxViewport != null;
+  const minLayoutVp = options.minLayoutViewport;
+  const maxLayoutVp = options.maxLayoutViewport;
+
+  if (
+    !hasBreakpointOverride &&
+    minLayoutVp != null &&
+    maxLayoutVp != null &&
+    minLayoutVp < maxLayoutVp
+  ) {
+    const minLayoutRem = minLayoutVp / rootFontSize;
+    const maxLayoutRem = maxLayoutVp / rootFontSize;
+    const layoutSlope = (maxNum - minNum) / (maxLayoutRem - minLayoutRem);
+
+    // Extrapolate to global viewport boundaries
+    minNum = minNum - layoutSlope * (minLayoutRem - minViewportRem);
+    maxNum = maxNum + layoutSlope * (maxViewportRem - maxLayoutRem);
+  }
+
   // Handle edge case where values are equal
   if (minNum === maxNum) {
     let value: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,18 @@ function normalizeOptions(options: FluidOptions): FluidOptions {
   ) {
     normalized.validateUnits = options.validateunits;
   }
+  if (
+    options.minlayoutviewport !== undefined &&
+    options.minLayoutViewport === undefined
+  ) {
+    normalized.minLayoutViewport = options.minlayoutviewport;
+  }
+  if (
+    options.maxlayoutviewport !== undefined &&
+    options.maxLayoutViewport === undefined
+  ) {
+    normalized.maxLayoutViewport = options.maxlayoutviewport;
+  }
 
   return normalized;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,24 @@ export interface FluidOptions {
   validateUnits?: boolean;
   /** @deprecated Use validateUnits instead. Lowercase variant for Prettier compatibility. */
   validateunits?: boolean;
+
+  /**
+   * Minimum layout viewport in pixels where the min fluid value is reached.
+   * When set, fluid scaling extrapolates beyond this point down to minViewport.
+   * Must satisfy: minViewport <= minLayoutViewport < maxLayoutViewport <= maxViewport
+   */
+  minLayoutViewport?: number;
+  /** @deprecated Use minLayoutViewport instead. Lowercase variant for Prettier compatibility. */
+  minlayoutviewport?: number;
+
+  /**
+   * Maximum layout viewport in pixels where the max fluid value is reached.
+   * When set, fluid scaling extrapolates beyond this point up to maxViewport.
+   * Must satisfy: minViewport <= minLayoutViewport < maxLayoutViewport <= maxViewport
+   */
+  maxLayoutViewport?: number;
+  /** @deprecated Use maxLayoutViewport instead. Lowercase variant for Prettier compatibility. */
+  maxlayoutviewport?: number;
 }
 
 /**
@@ -96,6 +114,8 @@ export interface ResolvedFluidOptions {
   useContainerQuery: boolean;
   debug: boolean;
   validateUnits: boolean;
+  minLayoutViewport?: number;
+  maxLayoutViewport?: number;
 }
 
 /**

--- a/tests/layout-viewport.test.ts
+++ b/tests/layout-viewport.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { calculateClampAdvanced } from "../src/clamp";
+import type { ResolvedFluidOptions } from "../src/types";
+
+const defaultOptions: ResolvedFluidOptions = {
+  minViewport: 375,
+  maxViewport: 1440,
+  useRem: true,
+  rootFontSize: 16,
+  checkAccessibility: true,
+  prefix: "",
+  separator: ":",
+  useContainerQuery: false,
+  debug: false,
+  validateUnits: true,
+};
+
+describe("layout viewport extrapolation", () => {
+  describe("basic extrapolation", () => {
+    it("should extrapolate min/max values when layout viewports are set", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minViewport: 375,
+        maxViewport: 1440,
+        minLayoutViewport: 480,
+        maxLayoutViewport: 1024,
+      };
+
+      // fl-p-4/8 → 1rem at 480px, 2rem at 1024px
+      const { result, validation } = calculateClampAdvanced(
+        "1rem",
+        "2rem",
+        options,
+      );
+
+      expect(validation.valid).toBe(true);
+      expect(result).toMatch(/^clamp\(/);
+
+      // The clamp min should be less than 1rem (extrapolated below 480px)
+      const minMatch = result.match(/clamp\(([\d.-]+)rem/);
+      expect(minMatch).not.toBeNull();
+      const clampMin = parseFloat(minMatch![1]);
+      expect(clampMin).toBeLessThan(1);
+
+      // The clamp max should be greater than 2rem (extrapolated above 1024px)
+      const maxMatch = result.match(/, ([\d.-]+)rem\)$/);
+      expect(maxMatch).not.toBeNull();
+      const clampMax = parseFloat(maxMatch![1]);
+      expect(clampMax).toBeGreaterThan(2);
+    });
+
+    it("should produce correct extrapolated values for known inputs", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minViewport: 375,
+        maxViewport: 1440,
+        minLayoutViewport: 480,
+        maxLayoutViewport: 1024,
+      };
+
+      // 1rem at 480px, 2rem at 1024px
+      // slope = (2 - 1) / ((1024/16) - (480/16)) = 1 / (64 - 30) = 1/34
+      // extrapolatedMin = 1 - (1/34) * (30 - 23.4375) = 1 - 0.193 = ~0.807
+      // extrapolatedMax = 2 + (1/34) * (90 - 64) = 2 + 0.765 = ~2.765
+      const { result } = calculateClampAdvanced("1rem", "2rem", options);
+
+      const minMatch = result.match(/clamp\(([\d.-]+)rem/);
+      const maxMatch = result.match(/, ([\d.-]+)rem\)$/);
+      const clampMin = parseFloat(minMatch![1]);
+      const clampMax = parseFloat(maxMatch![1]);
+
+      expect(clampMin).toBeCloseTo(0.8069, 2);
+      expect(clampMax).toBeCloseTo(2.7647, 2);
+    });
+
+    it("should work with px output mode", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        useRem: false,
+        minViewport: 375,
+        maxViewport: 1440,
+        minLayoutViewport: 480,
+        maxLayoutViewport: 1024,
+      };
+
+      const { result, validation } = calculateClampAdvanced(
+        "16px",
+        "32px",
+        options,
+      );
+
+      expect(validation.valid).toBe(true);
+      expect(result).toMatch(/^clamp\(/);
+      expect(result).toContain("px");
+
+      // Clamp min should be less than 16px
+      const minMatch = result.match(/clamp\(([\d.-]+)px/);
+      expect(minMatch).not.toBeNull();
+      expect(parseFloat(minMatch![1])).toBeLessThan(16);
+
+      // Clamp max should be greater than 32px
+      const maxMatch = result.match(/, ([\d.-]+)px\)$/);
+      expect(maxMatch).not.toBeNull();
+      expect(parseFloat(maxMatch![1])).toBeGreaterThan(32);
+    });
+  });
+
+  describe("no regression without layout viewports", () => {
+    it("should produce identical output when layout viewports are not set", () => {
+      const withoutLayout = calculateClampAdvanced(
+        "1rem",
+        "3rem",
+        defaultOptions,
+      );
+
+      const withUndefinedLayout: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minLayoutViewport: undefined,
+        maxLayoutViewport: undefined,
+      };
+      const withUndefined = calculateClampAdvanced(
+        "1rem",
+        "3rem",
+        withUndefinedLayout,
+      );
+
+      expect(withoutLayout.result).toBe(withUndefined.result);
+    });
+
+    it("should produce identical output when layout viewports equal global viewports", () => {
+      const withoutLayout = calculateClampAdvanced(
+        "1rem",
+        "3rem",
+        defaultOptions,
+      );
+
+      const withSameLayout: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minLayoutViewport: 375,
+        maxLayoutViewport: 1440,
+      };
+      const withSame = calculateClampAdvanced("1rem", "3rem", withSameLayout);
+
+      expect(withoutLayout.result).toBe(withSame.result);
+    });
+  });
+
+  describe("per-utility breakpoint override", () => {
+    it("should ignore layout viewports when per-utility breakpoints are set", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minLayoutViewport: 480,
+        maxLayoutViewport: 1024,
+      };
+
+      // With per-utility override, layout viewports should be bypassed
+      const withOverride = calculateClampAdvanced("1rem", "2rem", options, {
+        minViewport: 768,
+        maxViewport: 1280,
+      });
+
+      // Same as calling without layout viewports but with the override
+      const directOverride = calculateClampAdvanced(
+        "1rem",
+        "2rem",
+        defaultOptions,
+        { minViewport: 768, maxViewport: 1280 },
+      );
+
+      expect(withOverride.result).toBe(directOverride.result);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle minLayoutViewport equal to minViewport (no min extrapolation)", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minViewport: 375,
+        maxViewport: 1440,
+        minLayoutViewport: 375,
+        maxLayoutViewport: 1024,
+      };
+
+      const { result, validation } = calculateClampAdvanced(
+        "1rem",
+        "2rem",
+        options,
+      );
+
+      expect(validation.valid).toBe(true);
+      // Min should stay at 1rem since minLayoutViewport === minViewport
+      const minMatch = result.match(/clamp\(([\d.-]+)rem/);
+      expect(parseFloat(minMatch![1])).toBeCloseTo(1, 2);
+      // Max should be extrapolated
+      const maxMatch = result.match(/, ([\d.-]+)rem\)$/);
+      expect(parseFloat(maxMatch![1])).toBeGreaterThan(2);
+    });
+
+    it("should handle maxLayoutViewport equal to maxViewport (no max extrapolation)", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minViewport: 375,
+        maxViewport: 1440,
+        minLayoutViewport: 480,
+        maxLayoutViewport: 1440,
+      };
+
+      const { result, validation } = calculateClampAdvanced(
+        "1rem",
+        "2rem",
+        options,
+      );
+
+      expect(validation.valid).toBe(true);
+      // Min should be extrapolated
+      const minMatch = result.match(/clamp\(([\d.-]+)rem/);
+      expect(parseFloat(minMatch![1])).toBeLessThan(1);
+      // Max should stay at 2rem since maxLayoutViewport === maxViewport
+      const maxMatch = result.match(/, ([\d.-]+)rem\)$/);
+      expect(parseFloat(maxMatch![1])).toBeCloseTo(2, 2);
+    });
+
+    it("should work with negated values", () => {
+      const options: ResolvedFluidOptions = {
+        ...defaultOptions,
+        minLayoutViewport: 480,
+        maxLayoutViewport: 1024,
+      };
+
+      const { result, validation } = calculateClampAdvanced(
+        "1rem",
+        "2rem",
+        options,
+        { negate: true },
+      );
+
+      expect(validation.valid).toBe(true);
+      // Negated: clamp min/max are swapped and negative
+      expect(result).toContain("clamp(");
+      const minMatch = result.match(/clamp\(([-\d.]+)rem/);
+      expect(parseFloat(minMatch![1])).toBeLessThan(0);
+    });
+  });
+});


### PR DESCRIPTION
feat: add minLayoutViewport and maxLayoutViewport options for extrapolated fluid scaling boundaries